### PR TITLE
add observable-media-service to barrel

### DIFF
--- a/src/lib/media-query/index.ts
+++ b/src/lib/media-query/index.ts
@@ -11,4 +11,5 @@ export * from './providers/observable-media-service-provider';
 export * from './match-media';
 export * from './media-change';
 export * from './media-monitor';
+export * from './observable-media-service';
 export * from './_module';


### PR DESCRIPTION
Can't import ObservableMediaService from @angular/flex-layout after upgrade to beta 4